### PR TITLE
Upgrade VitePress to 1.0.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "eslint-plugin-vue": "^8.7.1",
         "glob": "^8.0.1",
         "gray-matter": "^4.0.3",
-        "vitepress": "^0.22.4"
+        "vitepress": "^1.0.0-alpha.4"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -408,6 +408,12 @@
         "@vue/shared": "3.2.33"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.1.4.tgz",
+      "integrity": "sha512-IiA0SvDrJEgXvVxjNkHPFfDx6SXw0b/TUkqMcDZWNg9fnCAHbTpoo59YfJ9QLFkwa3raau5vSlRVzMSLDnfdtQ==",
+      "dev": true
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.2.33",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.33.tgz",
@@ -475,6 +481,65 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.33.tgz",
       "integrity": "sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg==",
       "dev": true
+    },
+    "node_modules/@vueuse/core": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-8.6.0.tgz",
+      "integrity": "sha512-VirzExCm/N+QdrEWT7J4uSrvJ5hquKIAU9alQ37kUvIJk9XxCLxmfRnmekYc1kz2+6BnoyuKYXVmrMV351CB4w==",
+      "dev": true,
+      "dependencies": {
+        "@vueuse/metadata": "8.6.0",
+        "@vueuse/shared": "8.6.0",
+        "vue-demi": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.0",
+        "vue": "^2.6.0 || ^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-8.6.0.tgz",
+      "integrity": "sha512-F+CKPvaExsm7QgRr8y+ZNJFwXasn89rs5wth/HeX9lJ1q8XEt+HJ16Q5Sxh4rfG5YSKXrStveVge8TKvPjMjFA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.6.0.tgz",
+      "integrity": "sha512-Y/IVywZo7IfEoSSEtCYpkVEmPV7pU35mEIxV7PbD/D3ly18B3mEsBaPbtDkNM/QP3zAZ5mn4nEkOfddX4uwuIA==",
+      "dev": true,
+      "dependencies": {
+        "vue-demi": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.0",
+        "vue": "^2.6.0 || ^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.7.1",
@@ -572,6 +637,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/body-scroll-lock": {
+      "version": "4.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz",
+      "integrity": "sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==",
       "dev": true
     },
     "node_modules/boolbase": {
@@ -1615,6 +1686,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -1865,15 +1942,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prismjs": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
-      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -2082,6 +2150,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2258,15 +2337,18 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-0.22.4.tgz",
-      "integrity": "sha512-oZUnLO/SpYdThaBKefDeOiVlr0Rie4Ppx3FzMnMyLtJnI5GlBMNjqYqMy/4+umm/iC+ZDJfI+IlDKxv5fZnYzA==",
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-bOAA4KW6vYGlkbcrPLZLTKWTgXVroObU+o9xj9EENyEl6yg26WWvfN7DGA4BftjdM5O8nR93Z5khPQ3W/tFE7Q==",
       "dev": true,
       "dependencies": {
         "@docsearch/css": "^3.0.0",
         "@docsearch/js": "^3.0.0",
         "@vitejs/plugin-vue": "^2.3.2",
-        "prismjs": "^1.25.0",
+        "@vue/devtools-api": "^6.1.4",
+        "@vueuse/core": "^8.5.0",
+        "body-scroll-lock": "^4.0.0-beta.0",
+        "shiki": "^0.10.1",
         "vite": "^2.9.7",
         "vue": "^3.2.33"
       },
@@ -2274,8 +2356,20 @@
         "vitepress": "bin/vitepress.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=14.6.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "node_modules/vue": {
       "version": "3.2.33",
@@ -2288,6 +2382,32 @@
         "@vue/runtime-dom": "3.2.33",
         "@vue/server-renderer": "3.2.33",
         "@vue/shared": "3.2.33"
+      }
+    },
+    "node_modules/vue-demi": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.1.tgz",
+      "integrity": "sha512-xmkJ56koG3ptpLnpgmIzk9/4nFf4CqduSJbUM0OdPoU87NwRuZ6x49OLhjSa/fC15fV+5CbEnrxU4oyE022svg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue-eslint-parser": {
@@ -2713,6 +2833,12 @@
         "@vue/shared": "3.2.33"
       }
     },
+    "@vue/devtools-api": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.1.4.tgz",
+      "integrity": "sha512-IiA0SvDrJEgXvVxjNkHPFfDx6SXw0b/TUkqMcDZWNg9fnCAHbTpoo59YfJ9QLFkwa3raau5vSlRVzMSLDnfdtQ==",
+      "dev": true
+    },
     "@vue/reactivity": {
       "version": "3.2.33",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.33.tgz",
@@ -2779,6 +2905,32 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.33.tgz",
       "integrity": "sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg==",
       "dev": true
+    },
+    "@vueuse/core": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-8.6.0.tgz",
+      "integrity": "sha512-VirzExCm/N+QdrEWT7J4uSrvJ5hquKIAU9alQ37kUvIJk9XxCLxmfRnmekYc1kz2+6BnoyuKYXVmrMV351CB4w==",
+      "dev": true,
+      "requires": {
+        "@vueuse/metadata": "8.6.0",
+        "@vueuse/shared": "8.6.0",
+        "vue-demi": "*"
+      }
+    },
+    "@vueuse/metadata": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-8.6.0.tgz",
+      "integrity": "sha512-F+CKPvaExsm7QgRr8y+ZNJFwXasn89rs5wth/HeX9lJ1q8XEt+HJ16Q5Sxh4rfG5YSKXrStveVge8TKvPjMjFA==",
+      "dev": true
+    },
+    "@vueuse/shared": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-8.6.0.tgz",
+      "integrity": "sha512-Y/IVywZo7IfEoSSEtCYpkVEmPV7pU35mEIxV7PbD/D3ly18B3mEsBaPbtDkNM/QP3zAZ5mn4nEkOfddX4uwuIA==",
+      "dev": true,
+      "requires": {
+        "vue-demi": "*"
+      }
     },
     "acorn": {
       "version": "8.7.1",
@@ -2855,6 +3007,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "body-scroll-lock": {
+      "version": "4.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-4.0.0-beta.0.tgz",
+      "integrity": "sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==",
       "dev": true
     },
     "boolbase": {
@@ -3549,6 +3707,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -3737,12 +3901,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
-    "prismjs": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
-      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
-      "dev": true
-    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -3893,6 +4051,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4009,18 +4178,33 @@
       }
     },
     "vitepress": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-0.22.4.tgz",
-      "integrity": "sha512-oZUnLO/SpYdThaBKefDeOiVlr0Rie4Ppx3FzMnMyLtJnI5GlBMNjqYqMy/4+umm/iC+ZDJfI+IlDKxv5fZnYzA==",
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-bOAA4KW6vYGlkbcrPLZLTKWTgXVroObU+o9xj9EENyEl6yg26WWvfN7DGA4BftjdM5O8nR93Z5khPQ3W/tFE7Q==",
       "dev": true,
       "requires": {
         "@docsearch/css": "^3.0.0",
         "@docsearch/js": "^3.0.0",
         "@vitejs/plugin-vue": "^2.3.2",
-        "prismjs": "^1.25.0",
+        "@vue/devtools-api": "^6.1.4",
+        "@vueuse/core": "^8.5.0",
+        "body-scroll-lock": "^4.0.0-beta.0",
+        "shiki": "^0.10.1",
         "vite": "^2.9.7",
         "vue": "^3.2.33"
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "vue": {
       "version": "3.2.33",
@@ -4034,6 +4218,13 @@
         "@vue/server-renderer": "3.2.33",
         "@vue/shared": "3.2.33"
       }
+    },
+    "vue-demi": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.1.tgz",
+      "integrity": "sha512-xmkJ56koG3ptpLnpgmIzk9/4nFf4CqduSJbUM0OdPoU87NwRuZ6x49OLhjSa/fC15fV+5CbEnrxU4oyE022svg==",
+      "dev": true,
+      "requires": {}
     },
     "vue-eslint-parser": {
       "version": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "eslint-plugin-vue": "^8.7.1",
     "glob": "^8.0.1",
     "gray-matter": "^4.0.3",
-    "vitepress": "^0.22.4"
+    "vitepress": "^1.0.0-alpha.4"
   }
 }

--- a/site/.vitepress/config.js
+++ b/site/.vitepress/config.js
@@ -9,10 +9,14 @@ export default defineConfig({
     head: [
       ["meta", { name: "viewport", content: "width=device-width, initial-scale=1" } ],
     ],
+    footer: {
+      copyright: 'Copyright © 2017-2022 Wren Security'
+    },
     nav: [
       {
         text: "Home",
-        link: "/" },
+        link: "/"
+      },
       {
         text: "Projects",
         items: [
@@ -34,14 +38,15 @@ export default defineConfig({
         ]
       },
       {
-        text: "Sponsors", link: "/sponsors"
+        text: "Sponsors",
+        link: "/sponsors"
       },
     ],
     sidebar: {
       "/projects/wrenidm": [
         {
           text: "Wren:IDM",
-          children: [
+          items: [
             { text: "Overview", link: "/projects/wrenidm/" },
             { text: "Getting Started", link: "/projects/wrenidm/download" },
             { text: "Resources", link: "/projects/wrenidm/resources" },
@@ -51,7 +56,7 @@ export default defineConfig({
       "/projects/wrenam": [
         {
           text: "Wren:AM",
-          children: [
+          items: [
             { text: "Overview", link: "/projects/wrenam/" },
           ]
         },
@@ -59,7 +64,7 @@ export default defineConfig({
       "/projects/wrends": [
         {
           text: "Wren:DS",
-          children: [
+          items: [
             { text: "Overview", link: "/projects/wrends/" },
           ]
         },
@@ -67,14 +72,19 @@ export default defineConfig({
       "/projects/wrenicf": [
         {
           text: "Wren:ICF",
-          children: [
+          items: [
             { text: "Overview", link: "/projects/wrenicf/" },
           ]
         },
       ],
       "/community/": [
-        { text: "Contact", link: "/community/contact" },
-        { text: "Get Involved", link: "/community/join" },
+        {
+          text: 'Community',
+          items: [
+            { text: "Contact", link: "/community/contact" },
+            { text: "Get Involved", link: "/community/join" },
+          ]
+        }
       ],
     },
   },

--- a/site/.vitepress/theme/components/blog/Blog.vue
+++ b/site/.vitepress/theme/components/blog/Blog.vue
@@ -25,7 +25,7 @@ import { data as posts } from '../../../data/posts.data'
 
 <style scoped>
 article + article {
-  margin-top: 36px;
+  margin-top: 1.5rem;
   border-top: 1px solid #e0e0e0;
 }
 </style>

--- a/site/.vitepress/theme/components/blog/PostHeader.vue
+++ b/site/.vitepress/theme/components/blog/PostHeader.vue
@@ -33,6 +33,7 @@ function formatDate(date) {
 
 <style scoped>
 h1 {
+  margin-top: 1.5rem;
   margin-bottom: 5px;
 }
 

--- a/site/.vitepress/theme/custom.css
+++ b/site/.vitepress/theme/custom.css
@@ -1,13 +1,37 @@
 :root {
-  --c-brand: #c12233;
-  --c-brand-light: #da3244;
+  --vp-c-brand: #c12233;
+  --vp-c-brand-light: #dd3e4f;
+  --vp-c-brand-lighter: #e15665;
+  --vp-c-brand-dark: #dd3e4f;
+  --vp-c-brand-darker: #e05161;
 }
 
-.nav-bar .logo {
-  height: 30px;
-  margin-right: 8px;
+.dark {
+  --vp-c-brand: #dd3e4f;
 }
 
-.home-hero .figure .image {
-  max-height: 220px;
+.dark img {
+  filter: grayscale(1) invert(1);
+}
+
+.project-origin {
+  padding: 16px 24px;
+  display: flex;
+  justify-content: center;
+}
+
+.project-origin .custom-block {
+  max-width: 1152px;
+}
+
+@media (min-width: 640px) {
+  .project-origin {
+    padding: 16px 48px;
+  }
+}
+
+@media (min-width: 960px) {
+  .project-origin {
+    padding: 16px 64px;
+  }
 }

--- a/site/index.md
+++ b/site/index.md
@@ -1,15 +1,19 @@
 ---
-home: true
+layout: home
 title: 'Home'
-heroImage: /wrensec-logo.png
-heroAlt: 'Wren Security logo'
-heroText: 'The Wren Security Suite'
-tagline: 'Community-driven, open-source software for user authentication, user identity management, and single-sign-on.'
-actionText: Get Started
-actionLink: https://docs.wrensecurity.org
-altActionText: View on GitHub
-altActionLink: https://github.com/WrenSecurity
-
+hero:
+  name: Wren Security Suite
+  tagline: Community-driven, open-source software for user authentication, user identity management, and single-sign-on.
+  image:
+    src: /wrensec-logo.png
+    alt: Wren Security logo
+  actions:
+    - theme: brand
+      text: Get Started
+      link: https://docs.wrensecurity.org
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/WrenSecurity
 features:
   - title: 🗒️ Open-source Software
     details: Wren Security is an open-source community security suite. With roots in Sun Microsystems’ products, it adopted community projects formerly maintained by ForgeRock™.
@@ -17,12 +21,11 @@ features:
     details: Identity management system with flexible data model, multiple extension points and scripting support (Groovy and JavaScript). Can connect to and manage a wide range of systems through integrated Identity Connector Framework.
   - title: 🔐 Access Management
     details: Access management, entitlements and federation server platform. Provides centralized authentication and authorization for multiple realms with delegated administration.
-footer: Copyright © 2017-2022 Wren Security
 ---
 
-
-::: tip Project Origin
-
-Though our project originated with code that ForgeRock™ had previously released, we are not affiliated with ForgeRock™ in any way. Our projects are based on the very latest code from what was available under a CDDL license (OpenAM 13.5+, OpenDJ 3.5+, OpenIDM 4.5+, and OpenIG 4.0+). ForgeRock™ no longer releases any of the most recent versions of their software under an open-source license. ForgeRock™’s “Community Edition” are ancient versions of the projects. Join our community for the latest and greatest.
-
-:::
+<div class="project-origin">
+  <div class="tip custom-block">
+    <p class="custom-block-title">Project Origin</p>
+    <p>Though our project originated with code that ForgeRock™ had previously released, we are not affiliated with ForgeRock™ in any way. Our projects are based on the very latest code from what was available under a CDDL license (OpenAM 13.5+, OpenDJ 3.5+, OpenIDM 4.5+, and OpenIG 4.0+). ForgeRock™ no longer releases any of the most recent versions of their software under an open-source license. ForgeRock™’s “Community Edition” are ancient versions of the projects. Join our community for the latest and greatest.</p>
+  </div>
+</div>


### PR DESCRIPTION
Vitepress has been upgraded to the 1.0.0. It is still alpha release but i didn't notice any issues. This version contains dark mode by default :100:.