### PR TITLE
Add CVE Numbering Authority blog post.

### DIFF
--- a/site/blog/2023/10/cve-numbering-authority.md
+++ b/site/blog/2023/10/cve-numbering-authority.md
@@ -1,0 +1,32 @@
+---
+title: We've been authorized as CVE Numbering Authority
+date: 2023-10-17
+excerpt: |
+  It's our pleasure to announce, that Wren Security has been authorized by the Common Vulnerabilities and Exposures (CVE) Program as a CVE Numbering Authority (CNA).
+sidebar: false
+---
+
+<Post>
+
+It's our pleasure to announce, that Wren Security has been authorized by the Common Vulnerabilities and Exposures [CVE](https://www.cve.org) Program as a CVE Numbering Authority [CNA](https://www.cve.org/ResourcesSupport/Glossary?activeTerm=glossaryCNA#). As a CNA, we have the ability to directly assign CVE IDs and publish CVE records for vulnerabilities discovered in our projects.
+
+Security is a fundamental aspect of our efforts, which is even reflected in our name. Therefore, we have recently made several releases that include significant security improvements and have clarified our disclosure processes. And since the principles of open source dictate that we respect transparency, it was a natural step to contribute to the global initiative of identifying, defining, and cataloging publicly-disclosed cybersecurity vulnerabilities.
+
+It's a commitment, but we believe that it will help to build trust with our users.
+
+
+## What is CVE Program?
+
+The mission of the Common Vulnerabilities and Exposures (CVE®) program is to identify, define, and catalog publicly disclosed cybersecurity vulnerabilities. There is one CVE Record for each vulnerability in the catalog. The vulnerabilities are discovered then assigned and published by organizations from around the world that have partnered with the CVE Program. Partners publish CVE Records to communicate consistent descriptions of vulnerabilities. Information technology and cybersecurity professionals use CVE Records to ensure they are discussing the same issue, and to coordinate their efforts to prioritize and address the vulnerabilities.
+
+
+## What are CNAs?
+
+CNAs are organizations responsible for the regular assignment of CVE IDs to vulnerabilities, and for creating and publishing information about the Vulnerability in the associated CVE Record. Each CNA has a specific Scope of responsibility for vulnerability identification and publishing.
+
+
+## Disclosure
+
+If you think you've found a vulnerability, please don't disclose it publicly until you've checked with us. Please, refer to the [disclosure policy](https://wrensecurity.org/community/disclosure.html).
+
+</Post>


### PR DESCRIPTION
This PR adds a new blog post announcing that Wren Security has been authorized as a CVE Numbering Authority. 